### PR TITLE
Export end of run data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-py-kira",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "description": "Effortlessly run Python code in your React apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/usePython.ts
+++ b/src/hooks/usePython.ts
@@ -17,6 +17,11 @@ interface UsePythonProps {
   packages?: Packages
 }
 
+export type ReturnResult = {
+  returnValue: unknown
+  outputLength: number
+}
+
 export default function usePython(props?: UsePythonProps) {
   const { packages = {} } = props ?? {}
 
@@ -24,7 +29,7 @@ export default function usePython(props?: UsePythonProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [isRunning, setIsRunning] = useState(false)
   const [output, setOutput] = useState<string[]>([])
-  const [lastOutputNoNewline, setLastOutputNoNewline] = useState(false)
+  const [returnValue, setReturnValue] = useState<ReturnResult>()
   const [stdout, setStdout] = useState('')
   const [stderr, setStderr] = useState('')
   const [pendingCode, setPendingCode] = useState<string | undefined>()
@@ -109,6 +114,9 @@ export default function usePython(props?: UsePythonProps) {
             proxy(({ id, version }) => {
               setRunnerId(id)
               console.debug('Loaded pyodide version:', version)
+            }),
+            proxy((returnValue: undefined | ReturnResult) => {
+              setReturnValue(returnValue)
             }),
             allPackages
           )
@@ -276,6 +284,7 @@ del sys
     watchModules,
     unwatchModules,
     isAwaitingInput,
+    returnValue,
     sendInput: sendUserInput,
     prompt: runnerId ? getPrompt(runnerId) : ''
   }

--- a/src/types/Runner.ts
+++ b/src/types/Runner.ts
@@ -1,3 +1,5 @@
+import { ReturnResult } from "../hooks/usePython"
+
 export interface Runner {
   init: (
     stdout: (msg: string) => void,
@@ -10,6 +12,7 @@ export interface Runner {
       version: string
       banner?: string
     }) => void,
+    setReturnValue: (returnResult: ReturnResult) => void,
     packages?: string[][]
   ) => Promise<void>
   interruptExecution: () => void


### PR DESCRIPTION
Since comlink's proxy seems to send things in an indeterminate order -- causing isRunning to be false even though inputs are still coming in --and because I'm too lazy to implement a process queue, I decided to just send end-of-run statistics in the place of "isRunning" to verify if a run is really finished.