### PR TITLE
Use alternate CDN domain name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiralearning/react-py-kira",
-  "version": "1.10.19",
+  "version": "1.10.20",
   "description": "Effortlessly run Python code in your React apps (fork)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/workers/python-console-worker.ts
+++ b/src/workers/python-console-worker.ts
@@ -1,4 +1,4 @@
-importScripts("https://d1w1smnrzlh8wo.cloudfront.net/3rdParty/pyodide/pyodide/pyodide.js")
+importScripts("https://assets.kira-learning.com/3rdParty/pyodide/pyodide/pyodide.js")
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -1,4 +1,4 @@
-importScripts("https://d1w1smnrzlh8wo.cloudfront.net/3rdParty/pyodide/pyodide/pyodide.js")
+importScripts("https://assets.kira-learning.com/3rdParty/pyodide/pyodide/pyodide.js")
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>


### PR DESCRIPTION
# Summary
We have an existing alternate domain for the CDN serving kira-learning assets. This pull request updates 2 `importScripts()` calls to the kira-learning domain. Although both `d1w1smnrzlh8wo.cloudfront.net` and `assets.kira-learning.com` point to the same resources, the `assets.kira-learning.com` domain is less likely to be blocked by users of kira-learning.com.

# Testing
Imported package with changes locally. Observed network requests in-browser. Confirmed Pyodide resources were loading from assets.kira-learning.com.