### PR TITLE
Get zipp and importlib from CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiralearning/react-py-kira",
-  "version": "1.10.20",
+  "version": "1.10.21",
   "description": "Effortlessly run Python code in your React apps (fork)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -1,4 +1,6 @@
-importScripts("https://assets.kira-learning.com/3rdParty/pyodide/pyodide/pyodide.js")
+const CDN_URL = 'https://assets.kira-learning.com/3rdParty/pyodide/pyodide'
+
+importScripts(`${CDN_URL}/pyodide.js`)
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>
@@ -83,13 +85,13 @@ const python = {
         stdout(str)
       }
     })
-    await self.pyodide.loadPackage(['pyodide-http'])
+    await self.pyodide.loadPackage(['pyodide-http', `${CDN_URL}/zipp-3.20.2-py3-none-any.whl`, `${CDN_URL}/importlib_metadata-8.5.0-py3-none-any.whl`, `${CDN_URL}/importlib_resources-6.4.5-py3-none-any.whl`])
     if (packages[0].length > 0) {
       await self.pyodide.loadPackage(packages[0])
     }
     await self.pyodide.loadPackage(['micropip'])
     const micropip = self.pyodide.pyimport('micropip')
-    await micropip.install(['matplotlib', 'beautifulsoup4', 'pandas', 'numpy', 'setuptools', ]);
+    await micropip.install(['matplotlib', 'beautifulsoup4', 'pandas', 'numpy', 'setuptools']);
     if (packages[1].length > 0) {
       await micropip.install(packages[1])
     }


### PR DESCRIPTION
## Summary
These 2 packages were the only 2 not coming from a kira-learning domain. Explicitly get these packages from assets.kira-learning.com

## Testing
Imported package with changes locally. Observed network requests in-browser. Confirmed zipp, importlib_metadata, and importlib_resources were loading from assets.kira-learning.com.